### PR TITLE
fix(mcp): use symlink-safe entry-point guard so global bin runs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2154,7 +2154,7 @@
     },
     "packages/mcp": {
       "name": "@aluvia/mcp",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@aluvia/cli": "^1.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aluvia/mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Aluvia MCP server — Model Context Protocol tools for browser sessions and account",
   "license": "MIT",
   "author": "Aluvia",

--- a/packages/mcp/src/mcp-server.ts
+++ b/packages/mcp/src/mcp-server.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -260,8 +262,13 @@ async function main(): Promise<void> {
   console.error("Aluvia MCP server running on stdio");
 }
 
-// Only run when executed directly (not when imported for testing)
-const isMcpServer = process.argv[1]?.match(/(?:mcp-server)\.[jt]s$/);
+// Only run when executed directly (not when imported for testing).
+// Resolve process.argv[1] through any symlinks (e.g. npm's global bin -> dist/esm/mcp-server.js)
+// and compare to this module's URL. This is symlink-safe, unlike a filename regex which
+// fails when launched via the extension-less `aluvia-mcp` bin symlink.
+const entry = process.argv[1] ? pathToFileURL(realpathSync(process.argv[1])).href : "";
+// @ts-ignore - import.meta.url exists at runtime in ESM (the only build the bin/main uses)
+const isMcpServer = entry === import.meta.url;
 if (isMcpServer) {
   main().catch((err) => {
     console.error("Fatal error in MCP server:", err);


### PR DESCRIPTION
The module-entry guard matched process.argv[1] against /(?:mcp-server)\.[jt]s$/. When launched via npm's global bin symlink, argv[1] is the extension-less aluvia-mcp path, so the regex failed, main() never ran, and the server silently exited 0.

Resolve argv[1] through realpathSync and compare to import.meta.url, matching the fix already applied to @aluvia/cli in #18.