### PR TITLE
docs: point dashboard links to /login with source ref param

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository is organized as a monorepo with three packages:
 
 ### 1. Get Aluvia API key
 
-[Aluvia dashboard](https://dashboard.aluvia.io)
+[Aluvia dashboard](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fgithub.com%2Faluvia-connect%2Faluvia%2Fblob%2Fmain%2FREADME.md)
 
 ### 2. Install
 

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -74,7 +74,7 @@ await api.account.get(); // throws InvalidApiKeyError
 ```
 
 **Fix:**
-- Verify your API key is correct at [dashboard.aluvia.io](https://dashboard.aluvia.io)
+- Verify your API key is correct at [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fgithub.com%2Faluvia-connect%2Faluvia%2Fblob%2Fmain%2Fdocs%2Ferror-reference.md)
 - Account endpoints (`/account/...`) require an **account API token**, not a connection token
 - Check if the key has expired
 
@@ -301,7 +301,7 @@ export ALUVIA_API_KEY="your-api-key"
 **Context:** Any API call
 
 **Fix:**
-- Verify your API key at [dashboard.aluvia.io](https://dashboard.aluvia.io)
+- Verify your API key at [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fgithub.com%2Faluvia-connect%2Faluvia%2Fblob%2Fmain%2Fdocs%2Ferror-reference.md)
 - Account endpoints require an **account API token**
 - Connection endpoints can use either account or connection tokens
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ A step-by-step guide to installing, configuring, and running your first Aluvia-p
 ## Prerequisites
 
 - **Node.js 18+** — Aluvia uses native `fetch`, `AbortController`, and ES modules
-- **An Aluvia API key** — sign up at [dashboard.aluvia.io](https://dashboard.aluvia.io)
+- **An Aluvia API key** — sign up at [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fgithub.com%2Faluvia-connect%2Faluvia%2Fblob%2Fmain%2Fdocs%2Fgetting-started.md)
 
 ---
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -36,9 +36,9 @@
 
 ## Get an Aluvia API Key
 
-You need an API key to run the MCP server. Get one from the [Aluvia dashboard](https://dashboard.aluvia.io):
+You need an API key to run the MCP server. Get one from the [Aluvia dashboard](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fmcp):
 
-1. Sign up or sign in at [dashboard.aluvia.io](https://dashboard.aluvia.io)
+1. Sign up or sign in at [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fmcp)
 2. In your account, open the API & SDKs section
 3. Copy your API key
 
@@ -222,7 +222,7 @@ Full parameter and response details: [MCP Server Guide — Tool Reference](https
 
 | Resource             | URL                                                                                                                                                  |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Aluvia Dashboard** | [dashboard.aluvia.io](https://dashboard.aluvia.io)                                                                                                   |
+| **Aluvia Dashboard** | [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fmcp)                                                                                                   |
 | **npm**              | [npmjs.com/package/@aluvia/mcp](https://www.npmjs.com/package/@aluvia/mcp)                                                                           |
 | **Full MCP Guide**   | [docs/mcp-server-guide.md](https://github.com/aluvia-connect/sdk-node/blob/main/docs/mcp-server-guide.md)                                            |
 | **Aluvia SDK**       | [@aluvia/sdk](https://github.com/aluvia-connect/sdk-node) — CLI, adapters, and [quick start](https://github.com/aluvia-connect/sdk-node#quick-start) |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -25,9 +25,9 @@ This package provides the programmatic API: `AluviaClient`, `AluviaApi`, `connec
 
 ## Get an Aluvia API Key
 
-You need an API key to use the SDK. Get one from the [Aluvia dashboard](https://dashboard.aluvia.io):
+You need an API key to use the SDK. Get one from the [Aluvia dashboard](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fsdk):
 
-1. Sign up or sign in at [dashboard.aluvia.io](https://dashboard.aluvia.io)
+1. Sign up or sign in at [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fsdk)
 2. In your account, open the API & SDKs section
 3. Copy your API key
 
@@ -269,7 +269,7 @@ try {
 | **Main SDK README**        | [github.com/aluvia-connect/sdk-node](https://github.com/aluvia-connect/sdk-node)                                      |
 | **Client Technical Guide** | [docs/client-technical-guide.md](https://github.com/aluvia-connect/sdk-node/blob/main/docs/client-technical-guide.md) |
 | **API Technical Guide**    | [docs/api-technical-guide.md](https://github.com/aluvia-connect/sdk-node/blob/main/docs/api-technical-guide.md)       |
-| **Aluvia Dashboard**       | [dashboard.aluvia.io](https://dashboard.aluvia.io)                                                                    |
+| **Aluvia Dashboard**       | [dashboard.aluvia.io](https://dashboard.aluvia.io/login?ref=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40aluvia%2Fsdk)                                                                    |
 
 ---
 


### PR DESCRIPTION
Update all dashboard.aluvia.io references in docs to https://dashboard.aluvia.io/login and append a ?ref= attribution param identifying the source page:
- README.md -> GitHub README URL
- packages/sdk/README.md -> npm @aluvia/sdk
- packages/mcp/README.md -> npm @aluvia/mcp
- docs/getting-started.md, docs/error-reference.md -> their GitHub source URLs